### PR TITLE
Find columns before running `evaluate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 *.trace
+*.plist
+*.tpls

--- a/benches/evaluate.rs
+++ b/benches/evaluate.rs
@@ -4,6 +4,7 @@ use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
 use tuple::evaluate::evaluate;
 use tuple::expr::{concat, contains, ident, lit};
+use tuple::physical_expr::PhysicalExpr;
 use tuple::schema::{Schema, Type};
 use tuple::tuple::Tuple;
 
@@ -36,37 +37,41 @@ fn evaluate_benchmark(c: &mut Criterion) {
         .add(lit(5))
         .lt(lit(25))
         .and(ident("retailprice").gt(lit(1499.5)));
+    let expr = PhysicalExpr::new(expr, &schema);
     c.bench_function("math (size + 5 < 25 and retailprice > 1499.5)", |b| {
         b.iter(|| {
             black_box(tuples.iter().for_each(|tuple| {
-                evaluate(&tuple, &schema, &expr);
+                evaluate(&tuple, &expr);
             }))
         });
     });
 
     let expr = ident("mfgr").eq(lit("Manufacturer#1"));
+    let expr = PhysicalExpr::new(expr, &schema);
     c.bench_function("select 1/5 (mfgr == Manufacturer#1)", |b| {
         b.iter(|| {
             black_box(tuples.iter().for_each(|tuple| {
-                evaluate(&tuple, &schema, &expr);
+                evaluate(&tuple, &expr);
             }))
         })
     });
 
     let expr = ident("brand").eq(lit("Brand#44"));
+    let expr = PhysicalExpr::new(expr, &schema);
     c.bench_function("select 1/25 (brand == Brand#44)", |b| {
         b.iter(|| {
             black_box(tuples.iter().for_each(|tuple| {
-                evaluate(&tuple, &schema, &expr);
+                evaluate(&tuple, &expr);
             }))
         })
     });
 
     let expr = ident("container").eq(lit("WRAP CAN"));
+    let expr = PhysicalExpr::new(expr, &schema);
     c.bench_function("select 1/40 (container == WRAP CAN)", |b| {
         b.iter(|| {
             black_box(tuples.iter().for_each(|tuple| {
-                evaluate(&tuple, &schema, &expr);
+                evaluate(&tuple, &expr);
             }))
         })
     });
@@ -75,12 +80,13 @@ fn evaluate_benchmark(c: &mut Criterion) {
         concat(vec![ident("container"), ident("container")]),
         lit("CANWRAP"),
     ]);
+    let expr = PhysicalExpr::new(expr, &schema);
     c.bench_function(
         "string functions (contains(concat(container, container), CANWRAP)",
         |b| {
             b.iter(|| {
                 black_box(tuples.iter().for_each(|tuple| {
-                    evaluate(&tuple, &schema, &expr);
+                    evaluate(&tuple, &expr);
                 }))
             })
         },

--- a/src/bin/convert.rs
+++ b/src/bin/convert.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut tuple = TupleBuilder::new(&schema);
         let line = result?;
         let mut values = line.split('|');
-        let mut types = schema.types();
+        let mut types = schema.physical_attrs().map(|attr| attr.r#type);
         while let Some(r#type) = types.next() {
             let Some(value) = values.next() else {
                 eprintln!("unexpected end of row values on line {line_number}");

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,13 +1,12 @@
 use crate::physical_expr::{
     ArithmeticOperator, ComparisonOperator, LogicalOperator, Operator, PhysicalExpr as Expr,
 };
-use crate::schema::PhysicalAttrs;
 use crate::tuple::Tuple;
 use crate::value::Value;
 
 pub fn evaluate<'a>(tuple: &'a Tuple, expr: &Expr) -> Value<'a> {
     match expr {
-        Expr::Ident(ident) => evaluate_ident(tuple, *ident),
+        Expr::Ident(attrs) => tuple.get_by_physical_attrs(*attrs),
         Expr::Function(evaluate_function, args) => evaluate_function(tuple, args),
         Expr::Value(value) => value.clone(),
         Expr::IsNull { expr, negated } => evaluate_is_null(tuple, expr, *negated),
@@ -24,10 +23,6 @@ pub fn evaluate<'a>(tuple: &'a Tuple, expr: &Expr) -> Value<'a> {
         } => evaluate_between(tuple, expr, low, high, *negated),
         Expr::BinaryOp { lhs, op, rhs } => evaluate_binary_op(tuple, lhs, *op, rhs),
     }
-}
-
-fn evaluate_ident<'a>(tuple: &'a Tuple, attrs: PhysicalAttrs) -> Value<'a> {
-    tuple.get_by_physical_attrs(attrs)
 }
 
 pub fn concat<'a>(tuple: &'a Tuple, args: &Vec<Expr>) -> Value<'a> {

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,13 +1,13 @@
 use crate::physical_expr::{
     ArithmeticOperator, ComparisonOperator, LogicalOperator, Operator, PhysicalExpr as Expr,
-    ValueAttrs,
 };
+use crate::schema::PhysicalAttrs;
 use crate::tuple::Tuple;
 use crate::value::Value;
 
 pub fn evaluate<'a>(tuple: &'a Tuple, expr: &Expr) -> Value<'a> {
     match expr {
-        Expr::Ident(ident) => evaluate_ident(tuple, ident),
+        Expr::Ident(ident) => evaluate_ident(tuple, *ident),
         Expr::Function(evaluate_function, args) => evaluate_function(tuple, args),
         Expr::Value(value) => value.clone(),
         Expr::IsNull { expr, negated } => evaluate_is_null(tuple, expr, *negated),
@@ -26,15 +26,8 @@ pub fn evaluate<'a>(tuple: &'a Tuple, expr: &Expr) -> Value<'a> {
     }
 }
 
-fn evaluate_ident<'a>(
-    tuple: &'a Tuple,
-    ValueAttrs {
-        r#type,
-        position,
-        offset,
-    }: &ValueAttrs,
-) -> Value<'a> {
-    tuple.get_by_physical_attrs(*r#type, *position, *offset)
+fn evaluate_ident<'a>(tuple: &'a Tuple, attrs: PhysicalAttrs) -> Value<'a> {
+    tuple.get_by_physical_attrs(attrs)
 }
 
 pub fn concat<'a>(tuple: &'a Tuple, args: &Vec<Expr>) -> Value<'a> {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,5 +1,3 @@
-use crate::value::Value;
-
 #[derive(Clone, Copy)]
 pub enum ArithmeticOperator {
     Add,
@@ -41,8 +39,7 @@ pub enum Ident {
     QualifiedColumn { table: String, name: String },
 }
 
-#[allow(unused)]
-enum Literal {
+pub enum Literal {
     Number(String),
     Decimal(String),
     String(String),
@@ -50,10 +47,34 @@ enum Literal {
     Null,
 }
 
+impl<'a> From<i8> for Literal {
+    fn from(val: i8) -> Self {
+        Literal::Number(val.to_string())
+    }
+}
+
+impl<'a> From<i32> for Literal {
+    fn from(val: i32) -> Self {
+        Literal::Number(val.to_string())
+    }
+}
+
+impl<'a> From<f32> for Literal {
+    fn from(val: f32) -> Self {
+        Literal::Decimal(val.to_string())
+    }
+}
+
+impl<'a> From<&str> for Literal {
+    fn from(val: &str) -> Self {
+        Literal::String(val.to_string())
+    }
+}
+
 pub enum Expr {
     Ident(Ident),
     Function(Function),
-    Literal(Value<'static>),
+    Literal(Literal),
     IsNull {
         expr: Box<Expr>,
         negated: bool,
@@ -90,12 +111,12 @@ pub fn ident(value: &str) -> Expr {
     }
 }
 
-pub fn lit(value: impl Into<Value<'static>>) -> Expr {
+pub fn lit(value: impl Into<Literal>) -> Expr {
     Expr::Literal(value.into())
 }
 
 pub fn null() -> Expr {
-    Expr::Literal(Value::Null)
+    Expr::Literal(Literal::Null)
 }
 
 pub fn concat(args: Vec<Expr>) -> Expr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod evaluate;
 pub mod expr;
+pub mod physical_expr;
 pub mod schema;
 pub mod tuple;
 pub mod value;

--- a/src/physical_expr.rs
+++ b/src/physical_expr.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::evaluate::{concat, contains};
 use crate::expr::{
     ArithmeticOperator as ExprArithmeticOperator, ComparisonOperator as ExprComparisonOperator,
@@ -46,7 +44,7 @@ pub type Function = for<'a> fn(tuple: &'a Tuple, args: &Vec<PhysicalExpr>) -> Va
 pub enum PhysicalExpr {
     Ident(PhysicalAttrs),
     Function(Function, Vec<PhysicalExpr>),
-    Value(Value<'static>),
+    Value(Value<'static>), // TODO: in base we will need to tie it to the lifetime of the literal
     IsNull {
         expr: Box<PhysicalExpr>,
         negated: bool,
@@ -120,12 +118,12 @@ fn physical_function(function: ExprFunction, schema: &Schema) -> PhysicalExpr {
     }
 }
 
-fn physical_value(literal: ExprLiteral) -> PhysicalExpr {
+fn physical_value(literal: ExprLiteral<'static>) -> PhysicalExpr {
     // TODO: coerce if required
     let value = match literal {
         ExprLiteral::Number(number) => Value::Int32(number.parse().unwrap()),
         ExprLiteral::Decimal(decimal) => Value::Float32(decimal.parse().unwrap()),
-        ExprLiteral::String(string) => Value::String(Cow::Owned(string.into_bytes())),
+        ExprLiteral::String(string) => Value::String(string),
         ExprLiteral::Bool(bool) => Value::Int8(bool as i8),
         ExprLiteral::Null => Value::Null,
     };

--- a/src/physical_expr.rs
+++ b/src/physical_expr.rs
@@ -1,0 +1,214 @@
+use std::borrow::Cow;
+
+use crate::evaluate::{concat, contains};
+use crate::expr::{
+    ArithmeticOperator as ExprArithmeticOperator, ComparisonOperator as ExprComparisonOperator,
+    Expr, Function as ExprFunction, Ident as ExprIdent, Literal as ExprLiteral,
+    LogicalOperator as ExprLogicalOperator, Operator as ExprOperator,
+};
+use crate::schema::{Column, Schema, Type};
+use crate::tuple::Tuple;
+use crate::value::Value;
+
+#[derive(Clone, Copy)]
+pub enum ArithmeticOperator {
+    Add,
+    Sub,
+    Div,
+    Mul,
+}
+
+#[derive(Clone, Copy)]
+pub enum ComparisonOperator {
+    Lt,
+    Le,
+    Eq,
+    Neq,
+    Ge,
+    Gt,
+}
+
+#[derive(Clone, Copy)]
+pub enum LogicalOperator {
+    And,
+    Or,
+}
+
+#[derive(Clone, Copy)]
+pub enum Operator {
+    Arithmetic(ArithmeticOperator),
+    Comparison(ComparisonOperator),
+    Logical(LogicalOperator),
+}
+
+pub type Function = for<'a> fn(tuple: &'a Tuple, args: &Vec<PhysicalExpr>) -> Value<'a>;
+
+pub struct ValueAttrs {
+    pub r#type: Type,
+    pub position: usize,
+    pub offset: usize,
+}
+
+pub enum PhysicalExpr {
+    Ident(ValueAttrs),
+    Function(Function, Vec<PhysicalExpr>),
+    Value(Value<'static>),
+    IsNull {
+        expr: Box<PhysicalExpr>,
+        negated: bool,
+    },
+    InList {
+        expr: Box<PhysicalExpr>,
+        list: Vec<PhysicalExpr>,
+        negated: bool,
+    },
+    Between {
+        expr: Box<PhysicalExpr>,
+        low: Box<PhysicalExpr>,
+        high: Box<PhysicalExpr>,
+        negated: bool,
+    },
+    BinaryOp {
+        lhs: Box<PhysicalExpr>,
+        op: Operator,
+        rhs: Box<PhysicalExpr>,
+    },
+}
+
+impl PhysicalExpr {
+    pub fn new(expr: Expr, schema: &Schema) -> Self {
+        match expr {
+            Expr::Ident(ident) => physical_ident(ident, schema),
+            Expr::Function(function) => physical_function(function, schema),
+            Expr::Literal(literal) => physical_value(literal),
+            Expr::IsNull { expr, negated } => physical_is_null(*expr, negated, schema),
+            Expr::InList {
+                expr,
+                list,
+                negated,
+            } => physical_in_list(*expr, list, negated, schema),
+            Expr::Between {
+                expr,
+                low,
+                high,
+                negated,
+            } => physical_between(*expr, *high, *low, negated, schema),
+            Expr::BinaryOp { lhs, op, rhs } => physical_binary_op(*lhs, op, *rhs, schema),
+        }
+    }
+}
+
+fn physical_ident(ident: ExprIdent, schema: &Schema) -> PhysicalExpr {
+    let (r#type, position, offset) = match ident {
+        ExprIdent::Column(name) => schema
+            .find_column(&name)
+            .map(Column::physical_attrs)
+            .unwrap(),
+        ExprIdent::QualifiedColumn { table, name } => schema
+            .find_qualified_column(&table, &name)
+            .map(Column::physical_attrs)
+            .unwrap(),
+    };
+
+    PhysicalExpr::Ident(ValueAttrs {
+        r#type,
+        position,
+        offset,
+    })
+}
+
+fn physical_function(function: ExprFunction, schema: &Schema) -> PhysicalExpr {
+    let args = function
+        .args
+        .into_iter()
+        .map(|expr| PhysicalExpr::new(expr, schema))
+        .collect();
+    match function.name.as_str() {
+        "concat" => PhysicalExpr::Function(concat, args),
+        "contains" => PhysicalExpr::Function(contains, args),
+        _ => unimplemented!(),
+    }
+}
+
+fn physical_value(literal: ExprLiteral) -> PhysicalExpr {
+    // TODO: coerce if required
+    let value = match literal {
+        ExprLiteral::Number(number) => Value::Int32(number.parse().unwrap()),
+        ExprLiteral::Decimal(decimal) => Value::Float32(decimal.parse().unwrap()),
+        ExprLiteral::String(string) => Value::String(Cow::Owned(string.into_bytes())),
+        ExprLiteral::Bool(bool) => Value::Int8(bool as i8),
+        ExprLiteral::Null => Value::Null,
+    };
+
+    PhysicalExpr::Value(value)
+}
+
+fn physical_is_null(expr: Expr, negated: bool, schema: &Schema) -> PhysicalExpr {
+    let expr = Box::new(PhysicalExpr::new(expr, schema));
+    PhysicalExpr::IsNull { expr, negated }
+}
+
+fn physical_in_list(expr: Expr, list: Vec<Expr>, negated: bool, schema: &Schema) -> PhysicalExpr {
+    let expr = Box::new(PhysicalExpr::new(expr, schema));
+    let list = list
+        .into_iter()
+        .map(|expr| PhysicalExpr::new(expr, schema))
+        .collect();
+    PhysicalExpr::InList {
+        expr,
+        list,
+        negated,
+    }
+}
+
+fn physical_between(
+    expr: Expr,
+    high: Expr,
+    low: Expr,
+    negated: bool,
+    schema: &Schema,
+) -> PhysicalExpr {
+    let expr = Box::new(PhysicalExpr::new(expr, schema));
+    let high = Box::new(PhysicalExpr::new(high, schema));
+    let low = Box::new(PhysicalExpr::new(low, schema));
+    PhysicalExpr::Between {
+        expr,
+        low,
+        high,
+        negated,
+    }
+}
+
+fn physical_binary_op(lhs: Expr, op: ExprOperator, rhs: Expr, schema: &Schema) -> PhysicalExpr {
+    let lhs = Box::new(PhysicalExpr::new(lhs, schema));
+    let op = physical_operator(op);
+    let rhs = Box::new(PhysicalExpr::new(rhs, schema));
+    PhysicalExpr::BinaryOp { lhs, op, rhs }
+}
+
+fn physical_operator(op: ExprOperator) -> Operator {
+    match op {
+        ExprOperator::Arithmetic(arithmetic_operator) => {
+            Operator::Arithmetic(match arithmetic_operator {
+                ExprArithmeticOperator::Add => ArithmeticOperator::Add,
+                ExprArithmeticOperator::Sub => ArithmeticOperator::Sub,
+                ExprArithmeticOperator::Div => ArithmeticOperator::Div,
+                ExprArithmeticOperator::Mul => ArithmeticOperator::Mul,
+            })
+        }
+        ExprOperator::Comparison(comparison_operator) => {
+            Operator::Comparison(match comparison_operator {
+                ExprComparisonOperator::Lt => ComparisonOperator::Lt,
+                ExprComparisonOperator::Le => ComparisonOperator::Le,
+                ExprComparisonOperator::Eq => ComparisonOperator::Eq,
+                ExprComparisonOperator::Neq => ComparisonOperator::Neq,
+                ExprComparisonOperator::Ge => ComparisonOperator::Ge,
+                ExprComparisonOperator::Gt => ComparisonOperator::Gt,
+            })
+        }
+        ExprOperator::Logical(logical_operator) => Operator::Logical(match logical_operator {
+            ExprLogicalOperator::And => LogicalOperator::And,
+            ExprLogicalOperator::Or => LogicalOperator::Or,
+        }),
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -63,12 +63,8 @@ impl Schema {
         &self.columns
     }
 
-    pub fn positions(&self) -> impl Iterator<Item = usize> + use<'_> {
-        self.columns.iter().map(|Column { position, .. }| *position)
-    }
-
-    pub fn types(&self) -> impl Iterator<Item = Type> + use<'_> {
-        self.columns.iter().map(|Column { r#type, .. }| *r#type)
+    pub fn physical_attrs(&self) -> impl Iterator<Item = PhysicalAttrs> + use<'_> {
+        self.columns.iter().map(Column::physical_attrs)
     }
 
     pub fn len(&self) -> usize {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -27,13 +27,24 @@ pub struct Column {
     nullable: bool,
 }
 
+#[derive(Clone, Copy)]
+pub struct PhysicalAttrs {
+    pub r#type: Type,
+    pub position: usize,
+    pub offset: usize,
+}
+
 impl Column {
     pub fn position(&self) -> usize {
         self.position
     }
 
-    pub fn physical_attrs(&self) -> (Type, usize, usize) {
-        (self.r#type, self.position, self.offset)
+    pub fn physical_attrs(&self) -> PhysicalAttrs {
+        PhysicalAttrs {
+            r#type: self.r#type,
+            position: self.position,
+            offset: self.offset,
+        }
     }
 
     pub fn nullable(&self) -> bool {
@@ -80,8 +91,8 @@ impl Schema {
         self.columns[i].r#type
     }
 
-    pub fn get_physical_attrs(&self, pos: usize) -> (Type, usize) {
-        (self.columns[pos].r#type, self.columns[pos].offset)
+    pub fn get_physical_attrs(&self, i: usize) -> PhysicalAttrs {
+        self.columns[i].physical_attrs()
     }
 
     pub fn string_pointer_offsets(&self) -> impl Iterator<Item = usize> + use<'_> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -32,6 +32,10 @@ impl Column {
         self.position
     }
 
+    pub fn physical_attrs(&self) -> (Type, usize, usize) {
+        (self.r#type, self.position, self.offset)
+    }
+
     pub fn nullable(&self) -> bool {
         self.nullable
     }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -83,6 +83,7 @@ impl Tuple {
 
     /// Gets the value of the ith column of the schema. Note that the nullability of the column in
     /// the schema is ignored, null is returned based on the tuples null bitmap only.
+    #[inline]
     pub fn get_by_physical_attrs<'a>(
         &'a self,
         r#type: Type,
@@ -110,6 +111,7 @@ impl Tuple {
         }
     }
 
+    #[inline]
     pub fn get_bytes_by_physical_attrs<'a>(
         &'a self,
         r#type: Type,

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value<'a> {
     String(Cow<'a, [u8]>),
     Int8(i8),


### PR DESCRIPTION
```console
math (size + 5 < 25 and retailprice > 1499.5)
                        time:   [4.6781 ms 4.6939 ms 4.7103 ms]
                        change: [-37.357% -37.072% -36.783%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

Benchmarking select 1/5 (mfgr == Manufacturer#1): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.8s, enable flat sampling, or reduce sample count to 50.
select 1/5 (mfgr == Manufacturer#1)
                        time:   [1.9337 ms 1.9390 ms 1.9448 ms]
                        change: [-32.097% -31.879% -31.638%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  7 (7.00%) high mild
  2 (2.00%) high severe

Benchmarking select 1/25 (brand == Brand#44): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.9s, enable flat sampling, or reduce sample count to 50.
select 1/25 (brand == Brand#44)
                        time:   [1.5705 ms 1.5741 ms 1.5783 ms]
                        change: [-32.491% -32.235% -31.948%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking select 1/40 (container == WRAP CAN): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.1s, enable flat sampling, or reduce sample count to 50.
select 1/40 (container == WRAP CAN)
                        time:   [1.6046 ms 1.6087 ms 1.6133 ms]
                        change: [-35.425% -35.165% -34.855%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  6 (6.00%) high severe

string functions (contains(concat(container, container), CANWRAP)
                        time:   [15.300 ms 15.327 ms 15.353 ms]
                        change: [-10.278% -10.007% -9.7607%] (p = 0.00 < 0.05)
                        Performance has improved.
```