### PR TITLE
Decouple tuple schema

### DIFF
--- a/benches/evaluate.rs
+++ b/benches/evaluate.rs
@@ -22,7 +22,7 @@ fn evaluate_benchmark(c: &mut Criterion) {
         .add_column("comment".into(), Type::String, nullable);
 
     let mut r = File::open("part.tpls").expect("error opening part.tpls");
-    let tuples = std::iter::from_fn(|| match Tuple::read_from(&mut r, &schema) {
+    let tuples = std::iter::from_fn(|| match Tuple::read_from(&mut r) {
         Ok(tuple) => Some(Ok(tuple)),
         Err(err) => match err.kind() {
             std::io::ErrorKind::UnexpectedEof => None,

--- a/src/bin/convert.rs
+++ b/src/bin/convert.rs
@@ -48,10 +48,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_column("comment".into(), Type::String, nullable);
 
     while let Some((line_number, result)) = lines.next() {
-        let mut tuple = TupleBuilder::new(&schema);
         let line = result?;
+
+        let mut tuple = TupleBuilder::new();
         let mut values = line.split('|');
-        let mut types = schema.physical_attrs().map(|attr| attr.r#type);
+        let mut types = schema.types();
         while let Some(r#type) = types.next() {
             let Some(value) = values.next() else {
                 eprintln!("unexpected end of row values on line {line_number}");
@@ -63,6 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Type::Int8 => tuple.int8(value.parse()?),
                 Type::Int32 => tuple.int32(value.parse()?),
                 Type::Float32 => tuple.float32(value.parse()?),
+                Type::Null => tuple,
             }
         }
 

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -4,7 +4,7 @@ use crate::physical_expr::{
 use crate::tuple::Tuple;
 use crate::value::Value;
 
-#[inline]
+#[inline(always)]
 pub fn evaluate<'a>(tuple: &'a Tuple, expr: &Expr) -> Value<'a> {
     match expr {
         Expr::Ident(position) => tuple.get(*position),
@@ -100,7 +100,7 @@ fn evaluate_between<'a>(
     Value::Int8(((value >= low && value <= high) && !negated) as i8)
 }
 
-#[inline]
+#[inline(always)]
 fn evaluate_arithmetic_binary_op<'a>(
     tuple: &'a Tuple,
     lhs: &Expr,
@@ -118,7 +118,7 @@ fn evaluate_arithmetic_binary_op<'a>(
     }
 }
 
-#[inline]
+#[inline(always)]
 fn evaluate_comparison_binary_op<'a>(
     tuple: &'a Tuple,
     lhs: &Expr,
@@ -140,7 +140,7 @@ fn evaluate_comparison_binary_op<'a>(
     Value::Int8(result as i8)
 }
 
-#[inline]
+#[inline(always)]
 fn evaluate_logical_binary_op<'a>(
     tuple: &'a Tuple,
     lhs: &Expr,

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -6,7 +6,7 @@ use crate::value::Value;
 
 pub fn evaluate<'a>(tuple: &'a Tuple, expr: &Expr) -> Value<'a> {
     match expr {
-        Expr::Ident(attrs) => tuple.get_by_physical_attrs(*attrs),
+        Expr::Ident(position) => tuple.get(*position),
         Expr::Function(evaluate_function, args) => evaluate_function(tuple, args),
         Expr::Value(value) => value.clone(),
         Expr::IsNull { expr, negated } => evaluate_is_null(tuple, expr, *negated),
@@ -164,7 +164,7 @@ mod test {
     #[test]
     fn test_constant_expressions() {
         let schema = Schema::default();
-        let tuple = TupleBuilder::new(&schema).finish();
+        let tuple = TupleBuilder::new().finish();
 
         [
             (lit(1 as i32).add(lit(2 as i32)), Value::Int32(3)),
@@ -193,7 +193,7 @@ mod test {
             .add_qualified_column(Some("t1".into()), "c2".into(), Type::String, nullable)
             .add_column("c3".into(), Type::Float32, nullable)
             .add_qualified_column(Some("t1".into()), "c4".into(), Type::Int32, nullable);
-        let tuple = TupleBuilder::new(&schema)
+        let tuple = TupleBuilder::new()
             .null()
             .string(b"a")
             .float32(7.2)

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -4,6 +4,7 @@ use crate::physical_expr::{
 use crate::tuple::Tuple;
 use crate::value::Value;
 
+#[inline]
 pub fn evaluate<'a>(tuple: &'a Tuple, expr: &Expr) -> Value<'a> {
     match expr {
         Expr::Ident(position) => tuple.get(*position),
@@ -108,6 +109,7 @@ fn evaluate_binary_op<'a>(tuple: &'a Tuple, lhs: &Expr, op: Operator, rhs: &Expr
     }
 }
 
+#[inline]
 fn evaluate_arithmetic_binary_op<'a>(
     lhs: Value<'a>,
     op: ArithmeticOperator,
@@ -121,6 +123,7 @@ fn evaluate_arithmetic_binary_op<'a>(
     }
 }
 
+#[inline]
 fn evaluate_comparison_binary_op<'a>(
     lhs: Value<'a>,
     op: ComparisonOperator,
@@ -138,6 +141,7 @@ fn evaluate_comparison_binary_op<'a>(
     Value::Int8(result as i8)
 }
 
+#[inline]
 fn evaluate_logical_binary_op<'a>(
     lhs: Value<'a>,
     op: LogicalOperator,

--- a/src/physical_expr.rs
+++ b/src/physical_expr.rs
@@ -60,6 +60,7 @@ pub enum PhysicalExpr {
         high: Box<PhysicalExpr>,
         negated: bool,
     },
+    // TODO: try splitting up by operator type
     BinaryOp {
         lhs: Box<PhysicalExpr>,
         op: Operator,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -30,13 +30,6 @@ pub struct Column {
     nullable: bool,
 }
 
-#[derive(Clone, Copy)]
-pub struct PhysicalAttrs {
-    pub r#type: Type,
-    pub position: usize,
-    pub offset: usize,
-}
-
 impl Column {
     pub fn r#type(&self) -> Type {
         self.r#type
@@ -44,14 +37,6 @@ impl Column {
 
     pub fn position(&self) -> usize {
         self.position
-    }
-
-    pub fn physical_attrs(&self) -> PhysicalAttrs {
-        PhysicalAttrs {
-            r#type: self.r#type,
-            position: self.position,
-            offset: self.offset,
-        }
     }
 
     pub fn nullable(&self) -> bool {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -20,37 +20,6 @@ impl Type {
     }
 }
 
-pub struct OffsetIter<'a, T>
-where
-    T: Iterator<Item = &'a Type>,
-{
-    types: T,
-    offset: usize,
-}
-
-impl<'a, T> Iterator for OffsetIter<'a, T>
-where
-    T: Iterator<Item = &'a Type>,
-{
-    type Item = usize;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let r#type = self.types.next()?;
-        let offset = self.offset;
-        self.offset += r#type.size();
-        Some(offset)
-    }
-}
-
-impl<'a, T> OffsetIter<'a, T>
-where
-    T: Iterator<Item = &'a Type>,
-{
-    pub fn new(types: T) -> Self {
-        Self { types, offset: 0 }
-    }
-}
-
 #[derive(Clone, PartialEq, Debug)]
 pub struct Column {
     table: Option<String>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum Type {
     Null = 0,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -20,7 +20,7 @@ impl Type {
     }
 }
 
-pub struct StringOffsetIter<'a, T>
+pub struct OffsetIter<'a, T>
 where
     T: Iterator<Item = &'a Type>,
 {
@@ -28,31 +28,21 @@ where
     offset: usize,
 }
 
-impl<'a, T> Iterator for StringOffsetIter<'a, T>
+impl<'a, T> Iterator for OffsetIter<'a, T>
 where
     T: Iterator<Item = &'a Type>,
 {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let r#type = self.types.next()?;
-            match r#type {
-                Type::String => {
-                    let offset = self.offset;
-                    self.offset += r#type.size();
-                    break Some(offset);
-                }
-                _ => {
-                    self.offset += r#type.size();
-                    continue;
-                }
-            }
-        }
+        let r#type = self.types.next()?;
+        let offset = self.offset;
+        self.offset += r#type.size();
+        Some(offset)
     }
 }
 
-impl<'a, T> StringOffsetIter<'a, T>
+impl<'a, T> OffsetIter<'a, T>
 where
     T: Iterator<Item = &'a Type>,
 {

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -53,6 +53,7 @@ impl Tuple {
     }
 
     /// Gets the value of the ith column of the tuple.
+    #[inline]
     pub fn get<'a>(&'a self, position: usize) -> Value<'a> {
         let r#type = self.types[position];
         let offset = self.offsets[position];

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -239,10 +239,10 @@ impl Tuple {
     }
 }
 
-/// Creates a new tuple using only the columns in the schema. The schema offsets are expected to
-/// align with the offsets in the tuple. This is useful for creating composite key tuple out of
+/// Creates a new tuple using only the values at the given positions. The positions are expected to
+/// align with the values in the tuple. This is useful for creating composite key tuple out of
 /// non-contiguous columns.
-pub fn fit_tuple_with_schema(tuple: &Tuple, positions: impl Iterator<Item = usize>) -> Tuple {
+pub fn fit_tuple_with_positions(tuple: &Tuple, positions: impl Iterator<Item = usize>) -> Tuple {
     let mut builder = TupleBuilder::new();
     for position in positions {
         let value = tuple.get(position);

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -77,7 +77,7 @@ impl Tuple {
     }
 
     /// Gets the value of the ith column of the tuple.
-    #[inline]
+    #[inline(always)]
     pub fn get<'a>(&'a self, position: usize) -> Value<'a> {
         let r#type = self.types[position];
         let offset = self.offsets[position];

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,13 +1,28 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum Value<'a> {
     String(Cow<'a, [u8]>),
     Int8(i8),
     Int32(i32),
     Float32(f32),
     Null,
+}
+
+impl<'a> std::fmt::Debug for Value<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::String(value) => match std::str::from_utf8(value) {
+                Ok(s) => write!(f, "String({s})"),
+                Err(_) => write!(f, "String({:?})", value),
+            },
+            Value::Int8(value) => write!(f, "Int8({value})"),
+            Value::Int32(value) => write!(f, "Int32({value})"),
+            Value::Float32(value) => write!(f, "Float32({value})"),
+            Value::Null => write!(f, "Null"),
+        }
+    }
 }
 
 impl<'a> Eq for Value<'a> {}


### PR DESCRIPTION
```console
Benchmarking math (size + 5 < 25 and retailprice > 1499.5): Collecting 100 samples in estimated 5.1098 s (1200 iteration
math (size + 5 < 25 and retailprice > 1499.5)
                        time:   [4.1451 ms 4.1601 ms 4.1766 ms]
                        change: [-15.151% -14.713% -14.240%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

Benchmarking select 1/5 (mfgr == Manufacturer#1): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.7s, enable flat sampling, or reduce sample count to 50.
select 1/5 (mfgr == Manufacturer#1)
                        time:   [1.9280 ms 1.9381 ms 1.9484 ms]
                        change: [-4.8663% -4.2063% -3.5520%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking select 1/25 (brand == Brand#44): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.9s, enable flat sampling, or reduce sample count to 50.
select 1/25 (brand == Brand#44)
                        time:   [1.5879 ms 1.6009 ms 1.6142 ms]
                        change: [-2.3968% -1.7029% -1.0478%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking select 1/40 (container == WRAP CAN): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.4s, enable flat sampling, or reduce sample count to 50.
select 1/40 (container == WRAP CAN)
                        time:   [1.6914 ms 1.7072 ms 1.7242 ms]
                        change: [+1.3376% +2.1318% +2.8249%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

Benchmarking string functions (contains(concat(container, container), CANWRAP): Collecting 100 samples in estimated 6.08
string functions (contains(concat(container, container), CANWRAP)
                        time:   [15.118 ms 15.157 ms 15.197 ms]
                        change: [-2.7192% -2.4570% -2.1727%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```